### PR TITLE
fix direction of bit indicators in stringifyProof

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,19 +168,20 @@ const verifyProof = (proof, leaf, root) => {
  * @returns {string}
  */
 const stringifyProof = (proof) => {
-	let pathStr = ""
-	let indicators = 0
-	for(let i = proof.length - 2; i >= 0; i -= 2) {
-		indicators <<= 1
-		indicators = proof[i] ? (indicators | 1) : (indicators | 0)
-		pathStr = proof[i+1].substr(2) + pathStr
-	}
+  let pathStr = "" 
+  let indicators = 0
 
-	let indicatorStr = indicators.toString(16)
-	while (indicatorStr.length !== 64) {
-		indicatorStr = '0' + indicatorStr
-	}
-	return '0x' + indicatorStr + pathStr
+  for(let i = proof.length - 2; i >= 0; i -= 2) {
+   indicators <<= 1
+   indicators = proof[i] ? (indicators | 1) : (indicators | 0) 
+   pathStr = `${proof[i+1].substr(2)}${pathStr}`
+ }
+
+  let indicatorStr = indicators.toString(16)
+  while (indicatorStr.length !== 64) {
+   indicatorStr = '0' + indicatorStr
+  }
+  return '0x' + indicatorStr + pathStr
 }
 
 module.exports = { buildTree, hashAB, hashHeader, isPowerOfTwo, treePad, getProof, verifyProof, stringifyProof }

--- a/index.js
+++ b/index.js
@@ -168,20 +168,20 @@ const verifyProof = (proof, leaf, root) => {
  * @returns {string}
  */
 const stringifyProof = (proof) => {
-  let pathStr = "" 
-  let indicators = 0
+	let pathStr = "" 
+	let indicators = 0
 
-  for(let i = proof.length - 2; i >= 0; i -= 2) {
-   indicators <<= 1
-   indicators = proof[i] ? (indicators | 1) : (indicators | 0) 
-   pathStr = `${proof[i+1].substr(2)}${pathStr}`
- }
+	for(let i = proof.length - 2; i >= 0; i -= 2) {
+		indicators <<= 1
+		indicators = proof[i] ? (indicators | 1) : (indicators | 0) 
+		pathStr = `${proof[i+1].substr(2)}${pathStr}`
+	}
 
-  let indicatorStr = indicators.toString(16)
-  while (indicatorStr.length !== 64) {
-   indicatorStr = '0' + indicatorStr
-  }
-  return '0x' + indicatorStr + pathStr
+	let indicatorStr = indicators.toString(16)
+	while (indicatorStr.length !== 64) {
+		indicatorStr = '0' + indicatorStr
+	}
+	return '0x' + indicatorStr + pathStr
 }
 
 module.exports = { buildTree, hashAB, hashHeader, isPowerOfTwo, treePad, getProof, verifyProof, stringifyProof }


### PR DESCRIPTION
I have reversed the direction of the bits in the indicator word (before zero padding) Before, the bottom of the tree was at the left most bit, but the bottom of the tree should have been the right most bit.  